### PR TITLE
Add serial GUI terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# atmos_read
+# Atmos Read
+
+Este repositorio contiene un ejemplo sencillo de una interfaz en Python que actúa como una pequeña terminal gráfica. La aplicación lee continuamente desde un puerto serie y muestra todo lo recibido en una ventana de texto.
+
+## Requisitos
+
+- Python 3
+- [pyserial](https://pypi.org/project/pyserial/)
+
+Puedes instalar las dependencias con:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+Ejecuta el archivo `terminal_interface.py` indicando el puerto serie y la velocidad de baudios si son diferentes de los valores por defecto (`/dev/ttyUSB0` y `9600`):
+
+```bash
+python terminal_interface.py
+```
+
+Al cerrar la ventana la conexión se cierra de forma segura.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyserial

--- a/terminal_interface.py
+++ b/terminal_interface.py
@@ -1,0 +1,45 @@
+import tkinter as tk
+from tkinter.scrolledtext import ScrolledText
+import serial
+import threading
+
+
+class SerialTerminal(tk.Frame):
+    """Simple terminal widget that reads from a serial port."""
+
+    def __init__(self, master, port="/dev/ttyUSB0", baudrate=9600):
+        super().__init__(master)
+        self.serial = serial.Serial(port, baudrate, timeout=1)
+        self.text = ScrolledText(self, wrap="word", height=20, width=80)
+        self.text.pack(expand=True, fill="both")
+        self.running = True
+        self.thread = threading.Thread(target=self._read_serial, daemon=True)
+        self.thread.start()
+
+    def _read_serial(self):
+        while self.running:
+            line = self.serial.readline().decode("utf-8", errors="replace")
+            if line:
+                self.text.insert("end", line)
+                self.text.see("end")
+
+    def stop(self):
+        self.running = False
+        if self.serial.is_open:
+            self.serial.close()
+
+
+def main():
+    root = tk.Tk()
+    root.title("Atmos Read Terminal")
+    terminal = SerialTerminal(root)
+    terminal.pack(expand=True, fill="both")
+    def on_close():
+        terminal.stop()
+        root.destroy()
+    root.protocol("WM_DELETE_WINDOW", on_close)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple Tkinter terminal that reads from the serial port
- document how to install and run the app
- list pyserial dependency

## Testing
- `python -m py_compile terminal_interface.py`
- `python terminal_interface.py` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_6878cc41d8748333b4504f92feaaeced