### PR TITLE
Limit charts to last 300 samples

### DIFF
--- a/script.js
+++ b/script.js
@@ -132,6 +132,14 @@ function parseLine(line) {
     humChart.data.datasets[0].data.push(hum);
     presChart.data.datasets[0].data.push(pres);
 
+    // Keep only the last 300 samples
+    [tempChart, humChart, presChart].forEach((chart) => {
+        if (chart.data.labels.length > 300) {
+            chart.data.labels.shift();
+            chart.data.datasets[0].data.shift();
+        }
+    });
+
     tempChart.update('none');
     humChart.update('none');
     presChart.update('none');


### PR DESCRIPTION
## Summary
- manage chart data arrays so only the most recent 300 samples are stored

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e01b1639c8333944628f500a5e956